### PR TITLE
Fix OpenConn WAL handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   but report success.
 - `sqlitemigration` will no longer skip applying the repeatable migration
   if the final migration is empty.
+- `OpenConn` now sets a busy handler before enabling WAL
+  (thanks @anacrolix!).
 
 ## [0.8.0][] - 2021-11-07
 


### PR DESCRIPTION
Connection needs to be set to block on busy before WAL journal mode is set in case it hasn't already set by another connection.

Journal-mode statement needs to be finalized before closing connection on error.

See also https://github.com/crawshaw/sqlite/pull/113.