### PR TITLE
improve converting to Go string performance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Deprecated `sqlitex.Open` in favor of `sqlitex.NewPool`.
 
+### Fixed
+
+- Speed up internal string conversions
+  ([#66](https://github.com/zombiezen/go-sqlite/pull/66)).
+  Thank you [@ffmiruz](https://github.com/ffmiruz) for the profiling work!
+
 ## [1.0.0][] - 2023-12-07
 
 Version 1.0 is the first officially stable release of `zombiezen.com/go/sqlite`.

--- a/internal_test.go
+++ b/internal_test.go
@@ -1,0 +1,34 @@
+// Copyright 2024 Ross Light
+// SPDX-License-Identifier: ISC
+
+package sqlite
+
+import (
+	"testing"
+	"unsafe"
+
+	"modernc.org/libc"
+	"modernc.org/libc/sys/types"
+)
+
+func BenchmarkGoStringN(b *testing.B) {
+	tls := libc.NewTLS()
+	const want = "Hello, World!\n"
+	ptr, err := malloc(tls, types.Size_t(len(want)+1))
+	if err != nil {
+		b.Fatal(err)
+	}
+	defer libc.Xfree(tls, ptr)
+	for i := 0; i < len(want); i++ {
+		*(*byte)(unsafe.Pointer(ptr + uintptr(i))) = want[i]
+	}
+	b.ResetTimer()
+	b.ReportAllocs()
+
+	for i := 0; i < b.N; i++ {
+		got := goStringN(ptr, len(want))
+		if got != want {
+			b.Errorf("goStringN(%#x, %d) = %q; want %q", ptr, len(want), got, want)
+		}
+	}
+}

--- a/sqlite.go
+++ b/sqlite.go
@@ -1298,13 +1298,8 @@ func goStringN(s uintptr, n int) string {
 	if s == 0 {
 		return ""
 	}
-	var buf strings.Builder
-	buf.Grow(n)
-	for i := 0; i < n; i++ {
-		buf.WriteByte(*(*byte)(unsafe.Pointer(s)))
-		s++
-	}
-	return buf.String()
+	tmpStr := unsafe.String((*byte)(unsafe.Pointer(s)), n)
+	return strings.Clone(tmpStr)
 }
 
 // cFuncPointer converts a function defined by a function declaration to a C pointer.

--- a/sqlite.go
+++ b/sqlite.go
@@ -20,7 +20,6 @@ package sqlite
 import (
 	"bytes"
 	"fmt"
-	"strings"
 	"sync"
 	"time"
 	"unsafe"
@@ -1298,8 +1297,8 @@ func goStringN(s uintptr, n int) string {
 	if s == 0 {
 		return ""
 	}
-	tmpStr := unsafe.String((*byte)(unsafe.Pointer(s)), n)
-	return strings.Clone(tmpStr)
+	b := unsafe.Slice((*byte)(unsafe.Pointer(s)), n)
+	return string(b)
 }
 
 // cFuncPointer converts a function defined by a function declaration to a C pointer.


### PR DESCRIPTION
Due to out of place performance on [this bench](https://github.com/cvilsmeier/go-sqlite-bench) for large case i thought there could be easy performance wins.
Profiling on that, performance hit as the string got bigger due to this loop https://github.com/zombiezen/go-sqlite/blob/f46dbf8b767e074a46642cd87c3d0e0cafcc79b2/sqlite.go#L1297C2-L1308 

This PR instead convert to unsafe string all at once and then clone it to get safe string. The performance for 1 byte string is the same and then keep improving as the string get bigger. 
~40% improvement for the large case on the benchmark. Also improve performance of other benchmark cases slightly.



