### PR TITLE
feat: ExecOptions.ExpectResults

### DIFF
--- a/sqlitex/exec.go
+++ b/sqlitex/exec.go
@@ -64,7 +64,7 @@ type ExecOptions struct {
 	// and the execution function returns the error value.
 	ResultFunc func(stmt *sqlite.Stmt) error
 
-	// ExpectRows, if set will cause Execute calls to return [ErrNoRows] if the statement returns no rows.
+	// ExpectRows, if enabled,  will cause Execute calls to return [ErrNoRows] if the statement returns no rows.
 	ExpectRows bool
 }
 

--- a/sqlitex/query.go
+++ b/sqlitex/query.go
@@ -9,8 +9,10 @@ import (
 	"zombiezen.com/go/sqlite"
 )
 
-var errNoResults = errors.New("sqlite: statement has no results")
-var errMultipleResults = errors.New("sqlite: statement has multiple result rows")
+var (
+	ErrNoResults       = errors.New("sqlite: statement has no results")
+	ErrMultipleResults = errors.New("sqlite: statement has multiple result rows")
+)
 
 func resultSetup(stmt *sqlite.Stmt) error {
 	hasRow, err := stmt.Step()
@@ -20,7 +22,7 @@ func resultSetup(stmt *sqlite.Stmt) error {
 	}
 	if !hasRow {
 		stmt.Reset()
-		return errNoResults
+		return ErrNoResults
 	}
 	return nil
 }
@@ -33,7 +35,7 @@ func resultTeardown(stmt *sqlite.Stmt) error {
 	}
 	if hasRow {
 		stmt.Reset()
-		return errMultipleResults
+		return ErrMultipleResults
 	}
 	return stmt.Reset()
 }


### PR DESCRIPTION
- Export ErrNoResults/ErrMultipleResults to allow the caller to handle
  these conditions programmatically.
- Add ExpectResults option to allow Exec calls to return ErrNoresults
  when queries return no results.
- Tests for ExpectResults, using Execute

Alternate proposal for #85