### PR TITLE
Add Take function in the migration package.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,10 +11,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- Documented `OpenWAL` behavior on `sqlite.OpenConn`.
-
-### Added
-
 - `sqlitemigration.Pool` now has a new method `Take`
   so that it implements a common interface with `sqlitex.Pool`
   ([#97](https://github.com/zombiezen/go-sqlite/pull/97)).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased][]
 
+### Added
+
+- `sqlitemigration.Pool` now has a new method `Take`
+  so that it implements a common interface with `sqlitex.Pool`
+  ([#97](https://github.com/zombiezen/go-sqlite/pull/97)).
+
 ### Fixed
 
 - The error returned from `sqlitex.NewPool`

--- a/sqlitemigration/sqlitemigration.go
+++ b/sqlitemigration/sqlitemigration.go
@@ -130,8 +130,16 @@ func (p *Pool) Close() error {
 	return p.pool.Close()
 }
 
-// Get gets an SQLite connection from the pool.
+// Get is an alias for Take
 func (p *Pool) Get(ctx context.Context) (*sqlite.Conn, error) {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	return p.Take(ctx)
+}
+
+// Takes an SQLite connection from the pool.
+func (p *Pool) Take(ctx context.Context) (*sqlite.Conn, error) {
 	tick := time.NewTicker(5 * time.Second)
 	for ready := false; !ready; {
 		// Inform Pool.open to keep trying.

--- a/sqlitemigration/sqlitemigration.go
+++ b/sqlitemigration/sqlitemigration.go
@@ -130,15 +130,41 @@ func (p *Pool) Close() error {
 	return p.pool.Close()
 }
 
-// Get is an alias for Take
+// Get obtains an SQLite connection from the pool,
+// waiting until the initial migration is complete.
+// Get is identical to [Pool.Take].
+//
+// If no connection is available,
+// Get will block until at least one connection is returned with [Pool.Put],
+// or until either the Pool is closed or the context is canceled.
+// If no connection can be obtained
+// or an error occurs while preparing the connection,
+// an error is returned.
+//
+// The provided context is also used to control the execution lifetime of the connection.
+// See [sqlite.Conn.SetInterrupt] for details.
+//
+// Applications must ensure that all non-nil Conns returned from Get
+// are returned to the same Pool with [Pool.Put].
 func (p *Pool) Get(ctx context.Context) (*sqlite.Conn, error) {
-	if ctx == nil {
-		ctx = context.Background()
-	}
 	return p.Take(ctx)
 }
 
-// Takes an SQLite connection from the pool.
+// Take obtains an SQLite connection from the pool,
+// waiting until the initial migration is complete.
+//
+// If no connection is available,
+// Take will block until at least one connection is returned with [Pool.Put],
+// or until either the Pool is closed or the context is canceled.
+// If no connection can be obtained
+// or an error occurs while preparing the connection,
+// an error is returned.
+//
+// The provided context is also used to control the execution lifetime of the connection.
+// See [sqlite.Conn.SetInterrupt] for details.
+//
+// Applications must ensure that all non-nil Conns returned from Take
+// are returned to the same Pool with [Pool.Put].
 func (p *Pool) Take(ctx context.Context) (*sqlite.Conn, error) {
 	tick := time.NewTicker(5 * time.Second)
 	for ready := false; !ready; {


### PR DESCRIPTION
Currently, the `pool.go` defines `Take` as the primary way to take a connection.
Ideally if the migrations package can follow the same interface, it would be easy for interoperability.

But migrations package does not provide `Take`, instead it provides `Get(ctx) (conn, error)` (which is different from the `Get(ctx) conn` in pool.go)

Changing the signature of `Get` would be a breaking change, but adding `Take` would instead atleast make a interoperable interface.