### PR TITLE
Use immediate rather than deferred transaction in sqlitemigration ensureAppID

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Address low-frequency errors with concurrent use of `sqlitemigration`
+  ([#99](https://github.com/zombiezen/go-sqlite/issues/99)).
 - The error returned from `sqlitex.NewPool`
   when trying to open an in-memory database
   now gives correct advice

--- a/sqlitemigration/sqlitemigration.go
+++ b/sqlitemigration/sqlitemigration.go
@@ -353,7 +353,19 @@ func rollback(conn *sqlite.Conn) {
 }
 
 func ensureAppID(conn *sqlite.Conn, wantAppID int32) (schemaVersion int32, err error) {
-	defer sqlitex.Save(conn)(&err)
+	// This transaction will later be upgraded to a write transaction. If at the point of upgrading
+	// to a write transaction, the database is locked, SQLite will fail immediately with
+	// SQLITE_BUSY and the busy timeout will have no effect, causing the pool to fail.
+	//
+	// If we use an immediate transaction, telling SQLite this is a write transaction, SQLite
+	// will attempt to lock the database immediately. If a lock cannot be acquired, the busy
+	// timeout is used allowing the transaction to wait until it can get a lock, thus allowing the
+	// pool to start successfully.
+	end, err := sqlitex.ImmediateTransaction(conn)
+	if err != nil {
+		return 0, err
+	}
+	defer end(&err)
 
 	var hasSchema bool
 	err = sqlitex.ExecuteTransient(conn, "VALUES ((SELECT COUNT(*) FROM sqlite_master) > 0);", &sqlitex.ExecOptions{

--- a/sqlitemigration/sqlitemigration_test.go
+++ b/sqlitemigration/sqlitemigration_test.go
@@ -957,8 +957,7 @@ func TestMigrate(t *testing.T) {
 		// Migrate and issue writes on one connection.
 		conn, err := sqlite.OpenConn(dbPath)
 		if err != nil {
-			t.Error(err)
-			return
+			t.Fatal(err)
 		}
 		defer func() {
 			if err := conn.Close(); err != nil {
@@ -966,7 +965,7 @@ func TestMigrate(t *testing.T) {
 			}
 		}()
 		if err := Migrate(ctx, conn, schema); err != nil {
-			t.Error("Migrate:", err)
+			t.Fatal("Migrate:", err)
 		}
 		for i := 0; i < 150; i++ {
 			if err := sqlitex.Execute(conn, "insert into foo values (?)", &sqlitex.ExecOptions{

--- a/sqlitemigration/sqlitemigration_test.go
+++ b/sqlitemigration/sqlitemigration_test.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"fmt"
 	"path/filepath"
+	"sync"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
@@ -880,6 +881,69 @@ func TestPool(t *testing.T) {
 		} else if !afterMigration {
 			t.Error("Foreign keys were disabled after migration")
 		}
+	})
+
+	t.Run("CanStartMultiplePoolsConcurrently", func(t *testing.T) {
+		var wg sync.WaitGroup
+
+		dbPath := filepath.Join(t.TempDir(), "concurrent-pools.db")
+		schema := Schema{
+			AppID: 0xedbeef,
+			Migrations: []string{
+				`create table foo ( id integer primary key not null );`,
+			},
+		}
+
+		primaryPool := NewPool(dbPath, schema, Options{})
+		defer func() {
+			if err := primaryPool.Close(); err != nil {
+				t.Error("pool.Close:", err)
+			}
+		}()
+
+		// run some queries on primary pool
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+
+			for i := 0; i < 150; i++ {
+				conn, err := primaryPool.Get(ctx)
+				if err != nil {
+					t.Error("primary pool, get connection:", err)
+					break
+				}
+
+				if err := sqlitex.Execute(conn, "insert into foo values (?)", &sqlitex.ExecOptions{
+					Args: []any{i},
+				}); err != nil {
+					t.Error("insert query:", err)
+				}
+
+				primaryPool.Put(conn)
+			}
+		}()
+
+		// attempt to create other pools while primary pool handles connections
+		for i := 0; i < 5; i++ {
+			wg.Add(1)
+			go func(i int) {
+				defer wg.Done()
+				pool := NewPool(dbPath, schema, Options{})
+				defer func() {
+					if err := pool.Close(); err != nil {
+						t.Error("pool.Close:", err)
+					}
+				}()
+				conn, err := pool.Get(ctx)
+				if err != nil {
+					t.Error("concurrent pool, get connection:", err)
+				} else {
+					pool.Put(conn)
+				}
+			}(i)
+		}
+
+		wg.Wait()
 	})
 }
 

--- a/sqlitemigration/sqlitemigration_test.go
+++ b/sqlitemigration/sqlitemigration_test.go
@@ -938,7 +938,7 @@ func TestMigrate(t *testing.T) {
 			go func(i int) {
 				defer wg.Done()
 
-				conn, err := sqlite.OpenConn(dbPath)
+				conn, err := sqlite.OpenConn(dbPath, sqlite.OpenReadWrite, sqlite.OpenCreate)
 				if err != nil {
 					t.Error(err)
 					return
@@ -955,7 +955,7 @@ func TestMigrate(t *testing.T) {
 		}
 
 		// Migrate and issue writes on one connection.
-		conn, err := sqlite.OpenConn(dbPath)
+		conn, err := sqlite.OpenConn(dbPath, sqlite.OpenReadWrite, sqlite.OpenCreate)
 		if err != nil {
 			t.Fatal(err)
 		}


### PR DESCRIPTION
This fixes an issue that can occur when using multiple `sqlitemigration` pools attempt to connect to the same database file concurrently. When opening a `sqlitemigration` pool while another pool is writing to the database, the pool may fail to startup with a `SQLITE_BUSY` error (shown as `database is locked`).

In my use case, I had some end-to-end tests running that started an API server and modified the database using a CLI. Both the CLI and the API server started a `sqlitemigration` pool and occasionally the CLI calls would fail due to this issue.

From my testing, the culprit is the `ensureAppID` function, which opens a deferred transaction that will later be upgraded to a write transaction. At the point of upgrading to a write transaction, if the database is locked, SQLite will fail immediately with `SQLITE_BUSY` [[1]](https://dzx.fr/blog/understanding-sqlite/#transaction-isolation) [[2]](https://www.sqlite.org/lang_transaction.html#read_transactions_versus_write_transactions) and the busy timeout will have no effect, causing the pool to fail to start.

If `ensureAppID` is switched use an immediate transaction, that tells SQLite this is a write transaction. SQLite will attempt to lock the database immediately. If a lock cannot be acquired, the busy timeout is used allowing the transaction to wait until it can get a lock, thus allowing the pool to start successfully.

I've also included a test case. Please let me know on feedback on the test, it is a bit unwieldy. I'm not sure if it fits with the standards of this project.
