### PR TITLE
 Adjust `OpenFlags` comment wording for clarity when rendered 

### DIFF
--- a/openflags.go
+++ b/openflags.go
@@ -10,12 +10,13 @@ import (
 	lib "modernc.org/sqlite/lib"
 )
 
-// OpenFlags are [flags] used when opening a [Conn] via [OpenConn].
+// OpenFlags are [flags] used when opening a [Conn] via [OpenConn];
+// one flag from the first set below is required.
 //
 // [flags]: https://www.sqlite.org/c3ref/c_open_autoproxy.html
 type OpenFlags uint
 
-// One of the following flags must be passed to [OpenConn].
+// Required flags, one of which must be passed to [OpenConn].
 const (
 	// OpenReadOnly opens the database in read-only mode.
 	// If the database does not already exist, an error is returned.


### PR DESCRIPTION
When rendered via `godoc` or `pkgsite` (https://pkg.go.dev/zombiezen.com/go/sqlite#OpenFlags) the `OpenFlags` docs are confusing because of their wording. The comment for the group of required flags uses the word `following` but the comment is rendered _after_ that set of flags, meaning it is displayed immediately _before_ the set of optional flags. This suggests the second group is actually the set of required flags:

![image](https://github.com/user-attachments/assets/8d077045-ccc2-4728-992c-70b2e1170522)

This is a hard one to solve since the two groups of `OpenFlags` are one after the other and comments are written into the source above the group and but rendered after it in HTML. You _could_ move the comment inside each `const ()` group, but then technically that would be commenting on the first flag in each group. Likewise you could be explicit and mention the names of the flags you're referring to (as Go docs are want to do with functions), but then you're repeating yourself.

I've given this a shot in view of `godoc`'s standard placement of comments _after_ constant groups, but logically it's a hard problem in these circumstances.

Suggestions very welcome!