### PR TITLE
Add mapping of untyped nil args to `BindNull` to exec docs

### DIFF
--- a/sqlitex/exec.go
+++ b/sqlitex/exec.go
@@ -35,14 +35,14 @@ type ExecOptions struct {
 	//
 	// Basic reflection on Args is used to map:
 	//
-	//	integers    to BindInt64
-	//	floats      to BindFloat
-	//	[]byte      to BindBytes
-	//	string      to BindText
-	//	bool        to BindBool
-	//      untyped nil to BindNull
+	//  - integers    to BindInt64
+	//  - floats      to BindFloat
+	//  - []byte      to BindBytes
+	//  - string      to BindText
+	//  - bool        to BindBool
+	//  - untyped nil to BindNull
 	//
-	// All other kinds are printed using fmt.Sprint(v) and passed to BindText.
+	// All other kinds are printed using [fmt.Sprint] and passed to BindText.
 	Args []any
 
 	// Named is the set of named arguments to bind to the statement. Keys must
@@ -51,14 +51,14 @@ type ExecOptions struct {
 	//
 	// Basic reflection on Named is used to map:
 	//
-	//	integers    to BindInt64
-	//	floats      to BindFloat
-	//	[]byte      to BindBytes
-	//	string      to BindText
-	//	bool        to BindBool
-	//      untyped nil to BindNull
+	//  - integers    to BindInt64
+	//  - floats      to BindFloat
+	//  - []byte      to BindBytes
+	//  - string      to BindText
+	//  - bool        to BindBool
+	//  - untyped nil to BindNull
 	//
-	// All other kinds are printed using fmt.Sprint(v) and passed to BindText.
+	// All other kinds are printed using [fmt.Sprint] and passed to BindText.
 	Named map[string]any
 
 	// ResultFunc is called for each result row.
@@ -78,15 +78,14 @@ type ExecOptions struct {
 // query using the [sqlite.Stmt] Bind* methods. Basic reflection on args is used
 // to map:
 //
-//	integers    to BindInt64
-//	floats      to BindFloat
-//	[]byte      to BindBytes
-//	string      to BindText
-//	bool        to BindBool
-//      untyped nil to BindNull
+//   - integers    to BindInt64
+//   - floats      to BindFloat
+//   - []byte      to BindBytes
+//   - string      to BindText
+//   - bool        to BindBool
+//   - untyped nil to BindNull
 //
-// All other kinds are printed using fmt.Sprint(v) and passed
-// to BindText.
+// All other kinds are printed using [fmt.Sprint] and passed to BindText.
 //
 // Exec is implemented using the Stmt prepare mechanism which allows
 // better interactions with Go's type system and avoids pitfalls of

--- a/sqlitex/exec.go
+++ b/sqlitex/exec.go
@@ -35,11 +35,12 @@ type ExecOptions struct {
 	//
 	// Basic reflection on Args is used to map:
 	//
-	//	integers to BindInt64
-	//	floats   to BindFloat
-	//	[]byte   to BindBytes
-	//	string   to BindText
-	//	bool     to BindBool
+	//	integers    to BindInt64
+	//	floats      to BindFloat
+	//	[]byte      to BindBytes
+	//	string      to BindText
+	//	bool        to BindBool
+	//      untyped nil to BindNull
 	//
 	// All other kinds are printed using fmt.Sprint(v) and passed to BindText.
 	Args []any
@@ -50,11 +51,12 @@ type ExecOptions struct {
 	//
 	// Basic reflection on Named is used to map:
 	//
-	//	integers to BindInt64
-	//	floats   to BindFloat
-	//	[]byte   to BindBytes
-	//	string   to BindText
-	//	bool     to BindBool
+	//	integers    to BindInt64
+	//	floats      to BindFloat
+	//	[]byte      to BindBytes
+	//	string      to BindText
+	//	bool        to BindBool
+	//      untyped nil to BindNull
 	//
 	// All other kinds are printed using fmt.Sprint(v) and passed to BindText.
 	Named map[string]any
@@ -76,13 +78,14 @@ type ExecOptions struct {
 // query using the [sqlite.Stmt] Bind* methods. Basic reflection on args is used
 // to map:
 //
-//	integers to BindInt64
-//	floats   to BindFloat
-//	[]byte   to BindBytes
-//	string   to BindText
-//	bool     to BindBool
+//	integers    to BindInt64
+//	floats      to BindFloat
+//	[]byte      to BindBytes
+//	string      to BindText
+//	bool        to BindBool
+//      untyped nil to BindNull
 //
-// All other kinds are printed using fmt.Sprintf("%v", v) and passed
+// All other kinds are printed using fmt.Sprint(v) and passed
 // to BindText.
 //
 // Exec is implemented using the Stmt prepare mechanism which allows


### PR DESCRIPTION
In my app, values passed in from JSON (and elsewhere) where they could be a value or `NULL` in SQL are stored as typed pointers, such as `*string`. In order to ensure these are handled by `sqlitex` and bound as `BindNull`, the `nil` value needs to be passed as an untyped nil, rather than a `*string`

This needs to be handled on my side so this PR documents the handling of untyped nil to BindNull in the `ExecOptions` documentation, alongside how other types are handled.

This also slightly adjusts the default handling documentation, so each section mentions `fmt.Sprint(v)` and aligns with the implementation (https://github.com/zombiezen/go-sqlite/blob/main/sqlitex/exec.go#L327).