### PR TITLE
Fix variable shadowing in resultError that silently swallows function errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 [Unreleased]: https://github.com/zombiezen/go-sqlite/compare/v1.4.2...main
 
+## [Unreleased][]
+
+### Fixed
+
+- User-defined functions that return specific error codes are now correctly propagated
+  ([#133](https://github.com/zombiezen/go-sqlite/pull/133)).
+
 ## [1.4.2][] - 2025-05-23
 
 Version 1.4.2 updates the `modernc.org/sqlite` version to 1.37.1.

--- a/func.go
+++ b/func.go
@@ -162,15 +162,15 @@ func (ctx Context) result(v Value, err error) {
 	}
 }
 
-func (ctx Context) resultError(err error) {
-	errstr := err.Error()
-	cerrstr, cerr := libc.CString(errstr)
-	if cerr != nil {
-		panic(cerr)
+func (ctx Context) resultError(resultError error) {
+	errorMessage := resultError.Error()
+	cErrorMessage, err := libc.CString(errorMessage)
+	if err != nil {
+		panic(err)
 	}
-	defer libc.Xfree(ctx.tls, cerrstr)
-	lib.Xsqlite3_result_error(ctx.tls, ctx.ptr, cerrstr, int32(len(errstr)))
-	lib.Xsqlite3_result_error_code(ctx.tls, ctx.ptr, int32(ErrCode(err)))
+	defer libc.Xfree(ctx.tls, cErrorMessage)
+	lib.Xsqlite3_result_error(ctx.tls, ctx.ptr, cErrorMessage, int32(len(errorMessage)))
+	lib.Xsqlite3_result_error_code(ctx.tls, ctx.ptr, int32(ErrCode(resultError)))
 }
 
 // Value represents a value that can be stored in a database table.

--- a/func.go
+++ b/func.go
@@ -164,9 +164,9 @@ func (ctx Context) result(v Value, err error) {
 
 func (ctx Context) resultError(err error) {
 	errstr := err.Error()
-	cerrstr, err := libc.CString(errstr)
-	if err != nil {
-		panic(err)
+	cerrstr, cerr := libc.CString(errstr)
+	if cerr != nil {
+		panic(cerr)
 	}
 	defer libc.Xfree(ctx.tls, cerrstr)
 	lib.Xsqlite3_result_error(ctx.tls, ctx.ptr, cerrstr, int32(len(errstr)))

--- a/func_test.go
+++ b/func_test.go
@@ -251,6 +251,86 @@ func (f *sumintsFunction) Finalize(ctx Context) {
 	*f.finalCalled = true
 }
 
+func TestScalarFuncErrorCode(t *testing.T) {
+	c, err := OpenConn(":memory:", 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() {
+		if err := c.Close(); err != nil {
+			t.Error(err)
+		}
+	}()
+
+	// Register a scalar function that returns an error wrapping a specific
+	// SQLite result code (ResultReadOnly). If resultError correctly preserves
+	// the original error, the error code propagated through sqlite3_step should
+	// match ResultReadOnly.
+	err = c.CreateFunction("fail_readonly", &FunctionImpl{
+		NArgs:         0,
+		Deterministic: true,
+		Scalar: func(ctx Context, args []Value) (Value, error) {
+			return Value{}, ResultReadOnly.ToError()
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	stmt, _, err := c.PrepareTransient("SELECT fail_readonly();")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer stmt.Finalize()
+
+	_, stepErr := stmt.Step()
+	if stepErr == nil {
+		t.Fatal("Step() returned nil error; want error with code ResultReadOnly")
+	}
+	if got := ErrCode(stepErr); got != ResultReadOnly {
+		t.Errorf("ErrCode(stepErr) = %v; want %v", got, ResultReadOnly)
+	}
+}
+
+func TestScalarFuncPlainError(t *testing.T) {
+	c, err := OpenConn(":memory:", 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() {
+		if err := c.Close(); err != nil {
+			t.Error(err)
+		}
+	}()
+
+	// Register a scalar function that returns a plain (non-SQLite) error.
+	// resultError should propagate this as ResultError (generic SQLITE_ERROR).
+	err = c.CreateFunction("fail_generic", &FunctionImpl{
+		NArgs:         0,
+		Deterministic: true,
+		Scalar: func(ctx Context, args []Value) (Value, error) {
+			return Value{}, fmt.Errorf("something went wrong")
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	stmt, _, err := c.PrepareTransient("SELECT fail_generic();")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer stmt.Finalize()
+
+	_, stepErr := stmt.Step()
+	if stepErr == nil {
+		t.Fatal("Step() returned nil error; want error with code ResultError")
+	}
+	if got := ErrCode(stepErr); got != ResultError {
+		t.Errorf("ErrCode(stepErr) = %v; want %v", got, ResultError)
+	}
+}
+
 func TestCastTextToInteger(t *testing.T) {
 	tests := []struct {
 		text string


### PR DESCRIPTION
## Summary

- `Context.resultError` in `func.go` uses `cerrstr, err := libc.CString(errstr)`, which shadows the `err` parameter. After a successful `CString`, `err` is `nil`, so `ErrCode(err)` returns `ResultOK` (0) and `sqlite3_result_error_code(ctx, 0)` overrides the error code set by the preceding `sqlite3_result_error` call.
- Because SQLite then sees `SQLITE_OK`, `sqlite3_step` returns success and the Go `Step()` method returns `nil` — silently discarding every error from user-defined scalar and aggregate functions.
- Fix: rename the `CString` error variable to `cerr` to avoid shadowing the parameter.

## Test plan

- [x] Added `TestScalarFuncErrorCode`: registers a scalar function returning `ResultReadOnly.ToError()`, verifies `Step()` returns an error with `ErrCode == ResultReadOnly`
- [x] Added `TestScalarFuncPlainError`: registers a scalar function returning `fmt.Errorf(...)`, verifies `Step()` returns an error with `ErrCode == ResultError`
- [x] Both tests fail before the fix (`Step()` returns `nil`) and pass after
- [x] Full test suite passes (`go test ./...`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Human post-commentary

In adding some user functions Claude stumbled upon some failing tests from expected errors not being returned. It noticed errors were shadowed in this check. Diving into things myself I don't think the shadow is intentional since `CString` is pretty much never going to error, and shadowing just throws away most of the intention of the function itself. 